### PR TITLE
Fixed syntax error in posts.rb

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ActiveRecord::Base
 
-  belongs_to :user, :city
+  belongs_to :user
+  belongs_to :city
 
   validates :title,
             presence: true,


### PR DESCRIPTION
Moved the belongs_to relationships onto separate lines to fix "arity" error
