### PR TITLE
rolled back migrations and removed reference to table that doesnt exist

### DIFF
--- a/db/migrate/20160506192503_drop_city_posts_table.rb
+++ b/db/migrate/20160506192503_drop_city_posts_table.rb
@@ -1,5 +1,0 @@
-class DropCityPostsTable < ActiveRecord::Migration
-  def change
-    drop_table :city_posts
-  end
-end


### PR DESCRIPTION
Deleting a model through the command line removed a migration that created the cities_posts join table, which a later migration deleted. This threw an error so we rolled back, removed the migration that deleted the table, and rolled back forward, 
